### PR TITLE
Work/timeline test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,6 +28,10 @@ android {
     dataBinding {
         enabled = true
     }
+    // Always show the result of every unit test when running via command line, even if it passes.
+    testOptions.unitTests {
+        includeAndroidResources = true
+    }
 }
 
 dependencies {
@@ -95,4 +99,10 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'androidx.test:runner:1.2.0'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+
+    // AndroidX Test - JVM testing
+    testImplementation "androidx.test.ext:junit-ktx:1.1.1"
+    testImplementation "androidx.test:core-ktx:1.2.0"
+    testImplementation "org.robolectric:robolectric:4.3.1"
+    androidTestImplementation "androidx.arch.core:core-testing:2.1.0"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,12 +9,12 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
     defaultConfig {
         applicationId "com.example.jeeek"
-        minSdkVersion 29
-        targetSdkVersion 29
+        minSdkVersion 28
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -84,7 +84,7 @@ dependencies {
     kapt 'com.github.bumptech.glide:compiler:4.7.1'
 
     // Room dependency
-    def room_version = '2.2.4'
+    def room_version = '2.2.5'
     implementation "androidx.room:room-runtime:$room_version"
     kapt "androidx.room:room-compiler:$room_version"
 

--- a/app/src/androidTest/java/com/example/jeeek/viewmodel/TimelineViewModelTest.kt
+++ b/app/src/androidTest/java/com/example/jeeek/viewmodel/TimelineViewModelTest.kt
@@ -1,0 +1,84 @@
+package com.example.jeeek.viewmodel
+
+import android.app.Application
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import androidx.test.platform.app.InstrumentationRegistry
+import com.example.jeeek.domain.EmailPasswordPayload
+import com.example.jeeek.domain.Tweet
+import com.example.jeeek.repository.AuthRepository
+import com.example.jeeek.utils.getOrAwaitValue
+import com.google.firebase.FirebaseApp
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.runBlocking
+import org.junit.Before
+import org.junit.Test
+
+import org.junit.Assert.*
+import org.junit.Rule
+import timber.log.Timber
+
+class TimelineViewModelTest {
+
+    private lateinit var auth: FirebaseAuth
+    private lateinit var repository: AuthRepository
+    private lateinit var timelineViewModel: TimelineViewModel
+
+    @get:Rule
+    var instantExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+
+        auth = FirebaseAuth.getInstance()
+        repository = AuthRepository(auth)
+        val email = "tonouchi27@gmail.com"
+        val password = "udon2307"
+
+        runBlocking {
+            repository.signin(EmailPasswordPayload(email, password))
+        }
+
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val firebaseApp = FirebaseApp.initializeApp(appContext)
+        firebaseApp!!.setAutomaticResourceManagementEnabled(true)
+
+        timelineViewModel = TimelineViewModel(Application())
+
+    }
+
+    @Test
+    fun flagLiveDataTest() {
+
+        val observer = Observer<Boolean> {}
+        try {
+            timelineViewModel.flagForTest.observeForever(observer)
+            assertEquals(false, timelineViewModel.flagForTest.value)
+
+            timelineViewModel.flagForTest.value = true
+            assertEquals(true, timelineViewModel.flagForTest.value)
+        } catch (e: Exception) {
+            Timber.e(e.message)
+        } finally {
+            timelineViewModel.flagForTest.removeObserver(observer)
+        }
+    }
+
+    @Test
+    fun timelineTest() {
+
+        val observer = Observer<List<Tweet>> {}
+        try {
+            timelineViewModel.timeline.observeForever(observer)
+            timelineViewModel.getTimelineFromRepository()
+
+            val value = timelineViewModel.timeline.getOrAwaitValue()
+            assertNotNull(value)
+        } catch (e: Exception) {
+            Timber.e(e.message)
+        } finally {
+            timelineViewModel.timeline.removeObserver(observer)
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/jeeek/utils/LiveDataTestUtil.kt
+++ b/app/src/main/java/com/example/jeeek/utils/LiveDataTestUtil.kt
@@ -1,0 +1,42 @@
+package com.example.jeeek.utils
+
+import androidx.annotation.VisibleForTesting
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.Observer
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+
+
+@VisibleForTesting(otherwise = VisibleForTesting.NONE)
+fun <T> LiveData<T>.getOrAwaitValue(
+    time: Long = 2,
+    timeUnit: TimeUnit = TimeUnit.SECONDS,
+    afterObserve: () -> Unit = {}
+): T {
+    var data: T? = null
+    val latch = CountDownLatch(1)
+    val observer = object : Observer<T> {
+        override fun onChanged(o: T?) {
+            data = o
+            latch.countDown()
+            this@getOrAwaitValue.removeObserver(this)
+        }
+    }
+    this.observeForever(observer)
+
+    try {
+        afterObserve.invoke()
+
+        // Don't wait indefinitely if the LiveData is not set.
+        if (!latch.await(time, timeUnit)) {
+            throw TimeoutException("LiveData value was never set.")
+        }
+
+    } finally {
+        this.removeObserver(observer)
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    return data as T
+}

--- a/app/src/main/java/com/example/jeeek/viewmodel/TimelineViewModel.kt
+++ b/app/src/main/java/com/example/jeeek/viewmodel/TimelineViewModel.kt
@@ -51,9 +51,9 @@ class TimelineViewModel(application: Application) : AndroidViewModel(application
         get() = _eventNetworkError
 
     /**
-     * Flag to display the error message. This is private to avoid exposing a
-     * way to set this value to observers.
-     */
+    * Flag to display the error message. This is private to avoid exposing a
+    * way to set this value to observers.
+    */
     private var _isNetworkErrorShown = MutableLiveData<Boolean>(false)
 
     /**
@@ -63,6 +63,8 @@ class TimelineViewModel(application: Application) : AndroidViewModel(application
     val isNetworkErrorShown: LiveData<Boolean>
         get() = _isNetworkErrorShown
 
+
+    var flagForTest = MutableLiveData<Boolean>(false)
 
     fun getTimelineFromRepository(): LiveData<List<Tweet>> {
 


### PR DESCRIPTION
## 背景
- viewmodelやlivedataのテストを書きたかった

## 変更内容
- 前のPRでマージしたtimelineViewModelについてテストを追加
- 

## メモ
- firebase.initializeApp部分でかなり詰まった
  - instrumentalTestでやる必要がある
- livedataのobserveをするのをmainThreadでやる必要があり、シングルスレッドでtestを動作させる設定に詰まった
- AndroidManifestを含まなければいけない場合の設定、local/instrument testでできる範囲の違いなど、色々勉強になった


## 動作確認
AndroidStudio上でtestを実行して確認済み
